### PR TITLE
Allow user to change foreground fade duration

### DIFF
--- a/WYChart/Classes/WYPieChart/Main/WYPieChartView.h
+++ b/WYChart/Classes/WYPieChart/Main/WYPieChartView.h
@@ -78,6 +78,7 @@ typedef NS_ENUM(NSUInteger, WYPieChartAnimationStyle) {
 
 @property (nonatomic) CGFloat animationDuration;
 @property (nonatomic) WYPieChartAnimationStyle animationStyle;
+@property (nonatomic) CGFloat foregroundAnimationDuration;
 
 @property (nonatomic) WYPieChartStyle style;
 

--- a/WYChart/Classes/WYPieChart/Main/WYPieChartView.m
+++ b/WYChart/Classes/WYPieChart/Main/WYPieChartView.m
@@ -49,6 +49,7 @@
     _calculator = [[WYPieChartCalculator alloc] init];
     
     _animationDuration = DEFAULT_ANIMATION_DURATION;
+    _foregroundAnimationDuration = 1.0;
     
     _fillByGradient = true;
     _rotatable = true;
@@ -126,7 +127,7 @@
 }
 
 - (void)chartAnimationDidStop {
-    [UIView animateWithDuration:1.0
+    [UIView animateWithDuration:_foregroundAnimationDuration
                      animations:^{
                          _foregroundView.alpha = 1;
                      }];


### PR DESCRIPTION
Adds `foregroundAnimationDuration` to `WYPieChartView` so a user can change the speed of the fade in.

This is useful when you have a quick chart build animation and you want the labels to fade in quickly to match.